### PR TITLE
Fix undefined params in request if procedure has optional arguments

### DIFF
--- a/src/JsonRPC/ProcedureHandler.php
+++ b/src/JsonRPC/ProcedureHandler.php
@@ -299,6 +299,12 @@ class ProcedureHandler
             }
         }
 
+        if ($undefinedRequestParams = array_diff_key($requestParams, $params)) {
+            throw new InvalidArgumentException(
+                'Undefined arguments: '.implode(', ', array_keys($undefinedRequestParams))
+            );
+        }
+
         return $params;
     }
 }

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -4,16 +4,16 @@ namespace JsonRPC;
 
 require_once __DIR__.'/../vendor/autoload.php';
 
-define ('CURLOPT_URL', 10002);
-define ('CURLOPT_RETURNTRANSFER', 19913);
-define ('CURLOPT_CONNECTTIMEOUT', 78);
-define ('CURLOPT_MAXREDIRS', 68);
-define ('CURLOPT_SSL_VERIFYPEER', 64);
-define ('CURLOPT_POST', 47);
-define ('CURLOPT_POSTFIELDS', 10015);
-define ('CURLOPT_HTTPHEADER', 10023);
-define ('CURLOPT_HEADERFUNCTION', 20079);
-define ('CURLOPT_CAINFO', 10065);
+defined('CURLOPT_URL') || define('CURLOPT_URL', 10002);
+defined('CURLOPT_RETURNTRANSFER') || define('CURLOPT_RETURNTRANSFER', 19913);
+defined('CURLOPT_CONNECTTIMEOUT') || define('CURLOPT_CONNECTTIMEOUT', 78);
+defined('CURLOPT_MAXREDIRS') || define('CURLOPT_MAXREDIRS', 68);
+defined('CURLOPT_SSL_VERIFYPEER') || define('CURLOPT_SSL_VERIFYPEER', 64);
+defined('CURLOPT_POST') || define('CURLOPT_POST', 47);
+defined('CURLOPT_POSTFIELDS') || define('CURLOPT_POSTFIELDS', 10015);
+defined('CURLOPT_HTTPHEADER') || define('CURLOPT_HTTPHEADER', 10023);
+defined('CURLOPT_HEADERFUNCTION') || define('CURLOPT_HEADERFUNCTION', 20079);
+defined('CURLOPT_CAINFO') || define('CURLOPT_CAINFO', 10065);
 
 function extension_loaded($extension) {
     return HttpClientTest::$functions->extension_loaded($extension);

--- a/tests/ProcedureHandlerTest.php
+++ b/tests/ProcedureHandlerTest.php
@@ -143,6 +143,15 @@ class ProcedureHandlerTest extends PHPUnit_Framework_TestCase
         $handler->executeProcedure('getAllC');
     }
 
+    public function testUndefinedArguments()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+
+        $handler = new ProcedureHandler;
+        $handler->withClassAndMethod('getAllA', new A, 'getAll');
+        $handler->executeProcedure('getAllA', ['p1' => 3, 'p2' => 5, 'p333' => 7]);
+    }
+
     public function testBeforeMethod()
     {
         $handler = new ProcedureHandler;


### PR DESCRIPTION
Hello!

I fixed send **undefined params** in request when procedure **has optional arguments**.

For example, we have procedure "getAll" which has two **required** arguments (p1, p2) and two **optional** (p3, p4):
```php
$handler = new ProcedureHandler;
$handler->withCallback('getAll', function ($p1, $p2, $p3 = 4, $p4 = 7) {
    return $p1 + $p2 + $p3 + $p4;
});
```
And before, we can send invalid request like this:
```json
{
    "jsonrpc": "2.0",
    "method": "getAll",
    "params": {
        "p1": 3,
        "p2": 5,
        "aaa": 9,
        "bbb": 12
    },
    "id": 1
}
```
where "**aaa**" and "**bbb**" are undefined arguments in procedure "getAll" definition.

**Please merge this fix.**
Thanks.

---

Additionally, I **fixed PHP notices** on run phpunit (if curl extension is installed):
```
$ ./vendor/bin/phpunit
PHP Notice:  Constant CURLOPT_URL already defined in JsonRPC/tests/HttpClientTest.php on line 7
PHP Notice:  Constant CURLOPT_RETURNTRANSFER already defined in JsonRPC/tests/HttpClientTest.php on line 8
PHP Notice:  Constant CURLOPT_CONNECTTIMEOUT already defined in JsonRPC/tests/HttpClientTest.php on line 9
PHP Notice:  Constant CURLOPT_MAXREDIRS already defined in JsonRPC/tests/HttpClientTest.php on line 10
PHP Notice:  Constant CURLOPT_SSL_VERIFYPEER already defined in JsonRPC/tests/HttpClientTest.php on line 11
PHP Notice:  Constant CURLOPT_POST already defined in JsonRPC/tests/HttpClientTest.php on line 12
PHP Notice:  Constant CURLOPT_POSTFIELDS already defined in JsonRPC/tests/HttpClientTest.php on line 13
PHP Notice:  Constant CURLOPT_HTTPHEADER already defined in JsonRPC/tests/HttpClientTest.php on line 14
PHP Notice:  Constant CURLOPT_HEADERFUNCTION already defined in JsonRPC/tests/HttpClientTest.php on line 15
PHP Notice:  Constant CURLOPT_CAINFO already defined in JsonRPC/tests/HttpClientTest.php on line 16
PHPUnit 4.8.36 by Sebastian Bergmann and contributors.

................................................................. 65 / 93 ( 69%)
............................

Time: 93 ms, Memory: 6.00MB

OK (93 tests, 126 assertions)
```